### PR TITLE
Add hide_avatars setting

### DIFF
--- a/app/css/app.css
+++ b/app/css/app.css
@@ -14,6 +14,15 @@ html {
   text-align: center;
 }
 
+.list .item.item-button-right {
+  padding-right: 45px;
+}
+
+.list .item.item-no-avatar {
+  padding: 10px;
+  padding-right: 45px;
+}
+
 .icon-spin {
   -webkit-animation: spin 2s infinite linear;
   -moz-animation: spin 2s infinite linear;

--- a/app/partials/bookmarks/list.html
+++ b/app/partials/bookmarks/list.html
@@ -10,15 +10,15 @@
 		/>
 	</label>
 	<a
-		class="item item-avatar item-button-right"
-		ng-class="{active: $index == position}"
+		class="item item-button-right"
+		ng-class="{active: $index == position, 'item-avatar': $settings.hide_avatars == false, 'item-no-avatar': $settings.hide_avatars}"
 		ng-click="getToken(bookmark)"
 		ng-repeat="bookmark in bookmarks.bookmarks
 		          |byNameOrAccountNumber:query
 		          |orderBy:orderProp"
 	>
-		<img ng-if="!gravatar(bookmark)" ng-src="{{bookmark.avatar_url}}" />
-		<img ng-if="gravatar(bookmark)" gravatar-src="bookmark.avatar_url || bookmark.name" />
+		<img ng-if="!gravatar(bookmark) && !$settings.hide_avatars" ng-src="{{bookmark.avatar_url}}" />
+		<img ng-if="gravatar(bookmark) && !$settings.hide_avatars" gravatar-src="bookmark.avatar_url || bookmark.name" />
 		<h2>{{bookmark.name}}</h2>
 		<p>{{bookmark.account_number}}/{{bookmark.role_name}}</p>
 		<button

--- a/app/partials/settings.html
+++ b/app/partials/settings.html
@@ -5,7 +5,7 @@
 				<img class="full-image" src="dist/img/sentia.png" />
 			</div>
 		</div>
-		
+
 		<div class="card">
 			<div class="item item-divider">Locksmith</div>
 
@@ -137,6 +137,26 @@
 			</div>
 		</div>
 	</form>
+
+	<div class="card">
+		<div class="item item-divider">Interface</div>
+
+		<div
+			class="item item-toggle"
+		>
+			Hide avatars
+				<label class="toggle toggle-balanced">
+				<input
+						type="checkbox"
+					ng-model="$settings.hide_avatars"
+				/>
+				<div class="track">
+					<div class="handle"></div>
+				</div>
+			</label>
+		</div>
+
+	</div>
 
 
 	<p>&nbsp;</p>


### PR DESCRIPTION
Added `hide avatars` settings, wich will, well. Hide avatars.

When enabling the setting, the bookmark list will remove the avatar, and decrease the padding of the list items, greatly improving the space left for account names. I also decreased the padding for the regular view, as there were about 35 pixels left to save on the right side.

Show avatars:
![screenshot 2017-08-03 08 37 08](https://user-images.githubusercontent.com/19777/28909030-f815487c-7826-11e7-8f3f-7c51008fe4c1.png)

Hide avatars:
![screenshot 2017-08-03 08 35 37](https://user-images.githubusercontent.com/19777/28909044-0cc869de-7827-11e7-8fa7-196ebcb2b42d.png)

